### PR TITLE
Run ppxlib_ast cleanup.sh build script with bash

### DIFF
--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
@@ -31,6 +31,7 @@ depends: [
   "re"                  {with-test & >= "1.9.0"}
   "cinaps"              {with-test & >= "v0.12.1"}
   "odoc"                {with-doc}
+  "bash"                {build}
 ]
 conflicts: [
   "ocaml-migrate-parsetree" {< "2.0.0"}
@@ -39,7 +40,7 @@ conflicts: [
   "base-effects"
 ]
 build: [
-  ["sh" "./cleanup.sh"]
+  ["bash" "./cleanup.sh"]
   ["dune" "subst"] {dev}
   [
     "dune"


### PR DESCRIPTION
I noticed a [build failure](https://github.com/punchagan/opam-repository-ox/actions/runs/15637952123/job/44057931556#step:5:415) in my GitHub Action that seems to have introduced in a3a37dbaac572b94ae4e59b8b68dfd9cec723431.  This commit should fix it.  /cc @d-kalinichenko 