### PR TITLE
Add conf-which as a build dependency

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.2.0+ox/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+ox/opam
@@ -7,7 +7,8 @@ homepage: "https://ocaml.org"
 bug-reports: "https://github.com/oxcaml/oxcaml/issues"
 dev-repo: "git+https://github.com/oxcaml/oxcaml/flambda-backend#main"
 depends: [
-  "conf-autoconf"
+  "conf-autoconf"         {build}
+  "conf-which"            {build}
   "ocaml"                 {= "5.2.0" & post}
   "base-unix"             {post}
   "base-bigarray"         {post}


### PR DESCRIPTION
This PR adds `conf-which` as a build dependency -- required for some distros like archlinux. Also, marks the `conf-autoconf` dependency as a build dependency.