### PR TITLE
Fixes for `ocaml_simd`

### DIFF
--- a/packages/ocaml-variants/ocaml-variants.5.2.0+ox/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+ox/opam
@@ -94,7 +94,7 @@ url {
   src:
     "https://github.com/oxcaml/oxcaml/archive/refs/tags/5.2.0minus-11-opam.tar.gz"
   checksum:
-    "sha256=21dc6127a2a16522d2d3df890cb467c2886f1ba9918eb0d2a4d67246f85f072e"
+    "sha256=c33697ad5ee104d2029babbf50a7613405996d971bd47fe33ca851db6270f731"
 }
 patches: ["ignore-opam.patch"]
 extra-files: [

--- a/packages/ocaml-variants/ocaml-variants.5.2.0+ox/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.2.0+ox/opam
@@ -92,9 +92,9 @@ extra-source "init-menhir.tar.gz" {
 }
 url {
   src:
-    "https://github.com/oxcaml/oxcaml/archive/f74e02025e37931e048296af81134a1e10ec79c1.tar.gz"
+    "https://github.com/oxcaml/oxcaml/archive/refs/tags/5.2.0minus-11-opam.tar.gz"
   checksum:
-    "sha256=6d5cbccbfa453228f57a53f7aff226932c7bcf22c234bcbc51e920d3a5faa14b"
+    "sha256=21dc6127a2a16522d2d3df890cb467c2886f1ba9918eb0d2a4d67246f85f072e"
 }
 patches: ["ignore-opam.patch"]
 extra-files: [

--- a/packages/ocaml_simd/ocaml_simd.v0.18~preview.130.36+326/opam
+++ b/packages/ocaml_simd/ocaml_simd.v0.18~preview.130.36+326/opam
@@ -29,7 +29,7 @@ description: """
 """
 url {
   src:
-    "https://github.com/janestreet/ocaml_simd/archive/207ce4c9ce60cf52760bd1070521e9b8d1f89984.tar.gz"
+    "https://github.com/janestreet/ocaml_simd/archive/11052cb6467e4ed3459d519a2b3da90eb5748ac2.tar.gz"
   checksum:
-    "sha256=f44cf7ff9f3d7e92a10d2e5f01452de08311282b3cf8db81cf60061de744d59e"
+    "sha256=ddfc6907bd2c7dfc5ebb64ac73ef923a0b977dae551b0433f63ef55280804a4b"
 }

--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/files/cleanup.sh
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/files/cleanup.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 rm -rf bench dev doc examples metaquot metaquot_lifters old_rtd_doc print-diff runner runner_as_ppx src test traverse ppxlib*.opam
 

--- a/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
+++ b/packages/ppxlib_ast/ppxlib_ast.0.33.0+ox/opam
@@ -90,7 +90,7 @@ patches: [
 extra-files: [
   [
     "cleanup.sh"
-    "sha256=155384e36ed934037a17b790b87897af588194ebffa57146c93ccb776c816d7c"
+    "sha256=29db7be4fd7860181a36b8c052d1ef944f32918a7c8d6c74fc9b3e7539916d8c"
   ]
   [
     "ppxlib+ast+ast.ml.patch"


### PR DESCRIPTION
Updates compiler tag & `ocaml_simd` version, which is now installable. Also removes `set -euo pipefail` in ppxlib_ast, which was causing an issue with dune sandboxing in wsl/ubuntu.