### PR TITLE
fix js_of_ocaml patches

### DIFF
--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
@@ -1,10 +1,9 @@
 --- a/runtime/js/array.js
 +++ b/runtime/js/array.js
-@@ -131,3 +131,13 @@
-   for (var i = 1; i < len; i++) b[i] = 0;
-   return b
+@@ -249,3 +249,12 @@
+   return caml_array_make(len, init);
  }
-+
+
 +// Provides: caml_iarray_of_array const
 +function caml_iarray_of_array(a) {
 +  return a;
@@ -16,7 +15,7 @@
 +}
 --- a/runtime/wasm/array.wat
 +++ b/runtime/wasm/array.wat
-@@ -293,4 +293,13 @@
+@@ -403,4 +403,13 @@
                 (struct.get $float 0 (ref.cast (ref $float) (local.get $v)))
                 (local.get $len))))
        (ref.i31 (i32.const 0)))

--- a/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.1+ox/opam
+++ b/packages/js_of_ocaml-compiler/js_of_ocaml-compiler.6.0.1+ox/opam
@@ -126,7 +126,7 @@ extra-files: [
   ]
   [
     "js_of_ocaml-iarray-primitives.patch"
-    "sha256=037ad55684c9ac3801ff284839d8bb1290d2e750cd4bcb03b75e5f4ab69559c9"
+    "sha256=1cefd949dad720858306c87e349dd927c402f292d7b7c770542f0b28bc8dc1b8"
   ]
   [
     "js_of_ocaml-important-config-changes.patch"

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
@@ -1,10 +1,9 @@
 --- a/runtime/js/array.js
 +++ b/runtime/js/array.js
-@@ -131,3 +131,13 @@
-   for (var i = 1; i < len; i++) b[i] = 0;
-   return b
+@@ -249,3 +249,12 @@
+   return caml_array_make(len, init);
  }
-+
+
 +// Provides: caml_iarray_of_array const
 +function caml_iarray_of_array(a) {
 +  return a;
@@ -16,7 +15,7 @@
 +}
 --- a/runtime/wasm/array.wat
 +++ b/runtime/wasm/array.wat
-@@ -293,4 +293,13 @@
+@@ -403,4 +403,13 @@
                 (struct.get $float 0 (ref.cast (ref $float) (local.get $v)))
                 (local.get $len))))
        (ref.i31 (i32.const 0)))

--- a/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.0.1+ox/opam
+++ b/packages/js_of_ocaml-ppx/js_of_ocaml-ppx.6.0.1+ox/opam
@@ -115,7 +115,7 @@ extra-files: [
   ]
   [
     "js_of_ocaml-iarray-primitives.patch"
-    "sha256=037ad55684c9ac3801ff284839d8bb1290d2e750cd4bcb03b75e5f4ab69559c9"
+    "sha256=1cefd949dad720858306c87e349dd927c402f292d7b7c770542f0b28bc8dc1b8"
   ]
   [
     "js_of_ocaml-important-config-changes.patch"

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
@@ -1,10 +1,9 @@
 --- a/runtime/js/array.js
 +++ b/runtime/js/array.js
-@@ -131,3 +131,13 @@
-   for (var i = 1; i < len; i++) b[i] = 0;
-   return b
+@@ -249,3 +249,12 @@
+   return caml_array_make(len, init);
  }
-+
+
 +// Provides: caml_iarray_of_array const
 +function caml_iarray_of_array(a) {
 +  return a;
@@ -16,7 +15,7 @@
 +}
 --- a/runtime/wasm/array.wat
 +++ b/runtime/wasm/array.wat
-@@ -293,4 +293,13 @@
+@@ -403,4 +403,13 @@
                 (struct.get $float 0 (ref.cast (ref $float) (local.get $v)))
                 (local.get $len))))
        (ref.i31 (i32.const 0)))

--- a/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.0.1+ox/opam
+++ b/packages/js_of_ocaml-toplevel/js_of_ocaml-toplevel.6.0.1+ox/opam
@@ -118,7 +118,7 @@ extra-files: [
   ]
   [
     "js_of_ocaml-iarray-primitives.patch"
-    "sha256=037ad55684c9ac3801ff284839d8bb1290d2e750cd4bcb03b75e5f4ab69559c9"
+    "sha256=1cefd949dad720858306c87e349dd927c402f292d7b7c770542f0b28bc8dc1b8"
   ]
   [
     "js_of_ocaml-important-config-changes.patch"

--- a/packages/js_of_ocaml/js_of_ocaml.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
+++ b/packages/js_of_ocaml/js_of_ocaml.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
@@ -1,10 +1,9 @@
 --- a/runtime/js/array.js
 +++ b/runtime/js/array.js
-@@ -131,3 +131,13 @@
-   for (var i = 1; i < len; i++) b[i] = 0;
-   return b
+@@ -249,3 +249,12 @@
+   return caml_array_make(len, init);
  }
-+
+
 +// Provides: caml_iarray_of_array const
 +function caml_iarray_of_array(a) {
 +  return a;
@@ -16,7 +15,7 @@
 +}
 --- a/runtime/wasm/array.wat
 +++ b/runtime/wasm/array.wat
-@@ -293,4 +293,13 @@
+@@ -403,4 +403,13 @@
                 (struct.get $float 0 (ref.cast (ref $float) (local.get $v)))
                 (local.get $len))))
        (ref.i31 (i32.const 0)))

--- a/packages/js_of_ocaml/js_of_ocaml.6.0.1+ox/opam
+++ b/packages/js_of_ocaml/js_of_ocaml.6.0.1+ox/opam
@@ -115,7 +115,7 @@ extra-files: [
   ]
   [
     "js_of_ocaml-iarray-primitives.patch"
-    "sha256=037ad55684c9ac3801ff284839d8bb1290d2e750cd4bcb03b75e5f4ab69559c9"
+    "sha256=1cefd949dad720858306c87e349dd927c402f292d7b7c770542f0b28bc8dc1b8"
   ]
   [
     "js_of_ocaml-important-config-changes.patch"

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.0.1+ox/files/js_of_ocaml-iarray-primitives.patch
@@ -1,10 +1,9 @@
 --- a/runtime/js/array.js
 +++ b/runtime/js/array.js
-@@ -131,3 +131,13 @@
-   for (var i = 1; i < len; i++) b[i] = 0;
-   return b
+@@ -249,3 +249,12 @@
+   return caml_array_make(len, init);
  }
-+
+
 +// Provides: caml_iarray_of_array const
 +function caml_iarray_of_array(a) {
 +  return a;
@@ -16,7 +15,7 @@
 +}
 --- a/runtime/wasm/array.wat
 +++ b/runtime/wasm/array.wat
-@@ -293,4 +293,13 @@
+@@ -403,4 +403,13 @@
                 (struct.get $float 0 (ref.cast (ref $float) (local.get $v)))
                 (local.get $len))))
        (ref.i31 (i32.const 0)))

--- a/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.0.1+ox/opam
+++ b/packages/wasm_of_ocaml-compiler/wasm_of_ocaml-compiler.6.0.1+ox/opam
@@ -129,7 +129,7 @@ extra-files: [
   ]
   [
     "js_of_ocaml-iarray-primitives.patch"
-    "sha256=037ad55684c9ac3801ff284839d8bb1290d2e750cd4bcb03b75e5f4ab69559c9"
+    "sha256=1cefd949dad720858306c87e349dd927c402f292d7b7c770542f0b28bc8dc1b8"
   ]
   [
     "js_of_ocaml-important-config-changes.patch"


### PR DESCRIPTION
Installation of js_of_ocaml was previously failing due to a bad patch. This PR fixes that. After updating the patch, I'm able to successfully install js_of_ocaml.