### PR TITLE
Add oxidized ppx_deriving

### DIFF
--- a/packages/ppx_deriving/ppx_deriving.6.1.1+ox/opam
+++ b/packages/ppx_deriving/ppx_deriving.6.1.1+ox/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+version: "6.1.1+ox"
+maintainer: "whitequark <whitequark@whitequark.org>"
+authors: [ "whitequark <whitequark@whitequark.org>" ]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ppx_deriving"
+doc: "https://ocaml-ppx.github.io/ppx_deriving/"
+bug-reports: "https://github.com/ocaml-ppx/ppx_deriving/issues"
+dev-repo: "git+https://github.com/ocaml-ppx/ppx_deriving.git"
+tags: [ "syntax" ]
+build: [
+  ["dune" "subst"] {dev}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+  ["dune" "build" "@doc" "-p" name "-j" jobs] {with-doc}
+]
+depends: [
+  "ocaml" {>= "4.05.0"}
+  "dune" {>= "1.6.3"}
+  "cppo" {>= "1.1.0" & build}
+  "ocamlfind"
+  "ppx_derivers"
+  "ppxlib" {= "0.33.0+ox"}
+  "ounit2" {with-test}
+]
+synopsis: "Type-driven code generation for OCaml"
+description: """
+ppx_deriving provides common infrastructure for generating
+code based on type definitions, and a set of useful plugins
+for common tasks.
+"""
+url {
+  src:
+    "git+https://github.com/patricoferris/ppx_deriving.git#4cb09f54ff13e525804852190bfed8abb9267014"
+}


### PR DESCRIPTION
This is a quick patch for ppx_deriving (the patch pointed to gets ppx_deriving as is whilst accommodating the parsetree changes introduced by oxcaml, it does not do anything with the new parts of the parsetree). 

cc @avsm @jonludlam 