### PR TITLE
uutf.1.0.3 is incompatible with Cmdliner 2.0

### DIFF
--- a/packages/uutf/uutf.1.0.3+ox/opam
+++ b/packages/uutf/uutf.1.0.3+ox/opam
@@ -33,7 +33,7 @@ depends: [
 ]
 depopts: ["cmdliner"]
 conflicts: [
-  "cmdliner" {< "0.9.8"}
+  "cmdliner" {< "0.9.8" | >= "2.0.0"}
 ]
 build: [
   "ocaml"


### PR DESCRIPTION
This PR copies the relevant changes from
https://github.com/ocaml/opam-repository/commit/4d3fb27660140304a970c6e7c1e9101286364ee4 into this repository's definition of uutf.