### PR TITLE
Add oxcaml.action-required

### DIFF
--- a/packages/oxcaml/oxcaml.action-required/opam
+++ b/packages/oxcaml/oxcaml.action-required/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+synopsis: "Virtual package indicating dependency on OxCaml"
+description:
+"Virtual package whose installation always fails and displays the instructions
+for activating OxCaml's opam-repository overlay.
+
+The recommended method for creating new OxCaml switches is:
+
+opam switch create oxcaml oxcaml-compiler --repos ox=git+https://github.com/oxcaml/opam-repository.git,default
+
+Please see https://oxcaml.org/get-oxcaml/ for more information"
+maintainer: "Jane Street <opensource-contacts@janestreet.com>"
+authors: "Xavier Leroy and many contributors"
+homepage: "https://oxcaml.org"
+bug-reports: "https://github.com/oxcaml/oxcaml/issues"
+messages: ["OxCaml opam repository required - see https://oxcaml.org/get-oxcaml"]
+build: ["false" "- oxcaml/opam-repository is required"]
+post-messages: [
+"You appear to have tried to install a package which requires OxCaml without
+first adding/enabling the opam package repository for OxCaml. This repository
+can be added to your current switch with:
+
+opam repository add ox git+https://github.com/oxcaml/opam-repository.git
+
+Please see https://oxcaml.org/get-oxcaml/ for more information"]
+# This package will be replaced by either oxcaml.archived or oxcaml.latest when
+# oxcaml/opam-repository is enabled.
+conflicts: "oxcaml-compiler"
+flags: avoid-version
+# This package in oxcaml/opam-repository is intended to override the package in
+# ocaml/opam-repository so that once the user has added the overlay, the switch
+# upgrades to oxcaml.latest (or oxcaml.archived).
+available: false


### PR DESCRIPTION
This mirrors https://github.com/ocaml/opam-repository/pull/29809, the only difference being that our version ends with `available: false` (because having added the overlay repo, the oxcaml.latest and oxcaml.archived packages become available)