### PR TITLE
opam-core: update patch and drop oxcaml-compiler conflict

### DIFF
--- a/packages/opam-core/opam-core.2.5.0+ox/files/oxcaml.patch
+++ b/packages/opam-core/opam-core.2.5.0+ox/files/oxcaml.patch
@@ -12,7 +12,7 @@ index 750297365..afb37bbb0 100644
    with Scanf.Scan_failure _ -> () end
  done with Exit -> close_in c; exit 0
 diff --git a/src/core/opamConsole.ml b/src/core/opamConsole.ml
-index e0af36f6c..8e43c8145 100644
+index 1cc2354cd..9eadfb7ef 100644
 --- a/src/core/opamConsole.ml
 +++ b/src/core/opamConsole.ml
 @@ -643,6 +643,8 @@ let win32_print_functions = lazy (
@@ -25,7 +25,7 @@ index e0af36f6c..8e43c8145 100644
    let batch =
      debug () || not (disp_status_line ()) in
 diff --git a/src/core/opamProcess.ml b/src/core/opamProcess.ml
-index a1662e36b..3191b8447 100644
+index a1662e36b..c3ff4a235 100644
 --- a/src/core/opamProcess.ml
 +++ b/src/core/opamProcess.ml
 @@ -308,6 +308,9 @@ let resolve_command ?env ?dir name =
@@ -50,3 +50,12 @@ index a1662e36b..3191b8447 100644
  
  (** [create cmd args] create a new process to execute the command
      [cmd] with arguments [args]. If [stdout_file] or [stderr_file] are
+@@ -819,7 +822,7 @@ let truncate l =
+ 
+ let string_of_result ?(color=`yellow) r =
+   let b = Buffer.create 2048 in
+-  let print = Buffer.add_string b in
++  let print str = Buffer.add_string b str in
+   let println str =
+     print str;
+     Buffer.add_char b '\n' in

--- a/packages/opam-core/opam-core.2.5.0+ox/opam
+++ b/packages/opam-core/opam-core.2.5.0+ox/opam
@@ -44,7 +44,6 @@ depends: [
 ]
 conflicts: [
   "extlib-compat"
-  "oxcaml-compiler" {> "5.2.0minus25"}
 ]
 build: [
   ["./configure" "--disable-checks" "--prefix" prefix]
@@ -62,6 +61,6 @@ patches: ["oxcaml.patch"]
 extra-files: [
   [
     "oxcaml.patch"
-    "sha256=8f9d4b2374db740f73405320fe0d00d4ac3c4be67326f84979d1599b0f4e4592"
+    "sha256=ff360490f447eec0b2f051703f064eec7a9e7ce4562d64c9f142f6213445e00d"
   ]
 ]


### PR DESCRIPTION
Adjust oxcaml.patch with the changes required to support oxcaml-compiler 5.2.0minus31, and remove the corresponding upper-bound conflict.