### PR TITLE
relax the dependency on ocamlfind.1.9.8+ox to allow wiggle room

### DIFF
--- a/packages/oxcaml-ocamlfind-patches/oxcaml-ocamlfind-patches.enabled/opam
+++ b/packages/oxcaml-ocamlfind-patches/oxcaml-ocamlfind-patches.enabled/opam
@@ -11,7 +11,7 @@ depends: [
   ("oxcaml-ocamlformat" {post} | "oxcaml-ocamlformat-patches" {post})
   "oxcaml" {post}
   "ocamlfind" {build & (
-                 = "1.9.8+ox"
+                 >= "1.9.8+ox" & < "1.9.9~~"
                )}
 ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]


### PR DESCRIPTION
relax the dependency on ocamlfind.1.9.8+ox to allow wiggle room for other names like ocamlfind.1.9.8+ox2