### PR TITLE
oxcaml-compiler: update `ignore-opam.patch` to build under Dune.

### DIFF
--- a/packages/oxcaml-compiler/oxcaml-compiler.5.2.0minus25/files/ignore-opam.patch
+++ b/packages/oxcaml-compiler/oxcaml-compiler.5.2.0minus25/files/ignore-opam.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.common-ox
 +++ b/Makefile.common-ox
-@@ -150,9 +150,9 @@ $(ocamldir)/otherlibs/dune:
+@@ -168,9 +168,9 @@ $(ocamldir)/otherlibs/dune:
 
  $(ocamldir)/dune.runtime_selection:
  	if [ "$(RUNTIME_DIR)" = "runtime4" ]; then \

--- a/packages/oxcaml-compiler/oxcaml-compiler.5.2.0minus25/opam
+++ b/packages/oxcaml-compiler/oxcaml-compiler.5.2.0minus25/opam
@@ -104,7 +104,7 @@ patches: ["ignore-opam.patch"]
 extra-files: [
   [
     "ignore-opam.patch"
-    "sha256=6ece96cd3f06c3ed90f768bf63659266a670e5be0b2302354a2d0e87629ba049"
+    "sha256=184afd47127afb2aa8e7b62c0c308b0ed896c48d75d44d0c4fc7eae2106a7335"
   ]
 ]
 conflicts: [

--- a/packages/oxcaml-compiler/oxcaml-compiler.5.2.0minus31/files/ignore-opam.patch
+++ b/packages/oxcaml-compiler/oxcaml-compiler.5.2.0minus31/files/ignore-opam.patch
@@ -1,6 +1,6 @@
 --- a/Makefile.common-ox
 +++ b/Makefile.common-ox
-@@ -150,9 +150,9 @@ $(ocamldir)/otherlibs/dune:
+@@ -170,9 +170,9 @@ $(ocamldir)/otherlibs/dune:
 
  $(ocamldir)/dune.runtime_selection:
  	if [ "$(RUNTIME_DIR)" = "runtime4" ]; then \

--- a/packages/oxcaml-compiler/oxcaml-compiler.5.2.0minus31/opam
+++ b/packages/oxcaml-compiler/oxcaml-compiler.5.2.0minus31/opam
@@ -105,7 +105,7 @@ patches: ["ignore-opam.patch" "cut-fix.patch"]
 extra-files: [
   [
     "ignore-opam.patch"
-    "sha256=83d87c0cab3a660c5213b485280df287a81b63c1a3444f0ef2e0e6f3ed02597b"
+    "sha256=acf0443a54832e9f6b46c91335a7af63e52072308d0842f5d519d9ff670a29e5"
   ]
   [
     "cut-fix.patch"


### PR DESCRIPTION
I grabbed a nightly build of Dune following the merge of https://github.com/ocaml/dune/pull/14544, which addresses https://github.com/oxcaml/opam-repository/issues/48.

    $ dune --version
    "Nightly build 2026-05-26T04:59:37Z, git revision
    8c05d9a4985748ae6df18d7b2de1f4c7b49c8137"

Then I followed the reproduction steps from
https://github.com/oxcaml/opam-repository/issues/48. Trying to build failed with:

    $ dune exec bin/main.exe
    Error: Patch could not be applied to "Makefile.common-ox": hunk does not
    match file contents
    -> required by
       _build/_private/default/.pkg/oxcaml-compiler.5.2.0minus31-3cb23df524cf0589e2f8049a781af661/target
    -> required by
       _build/_private/default/.pkg/ocaml-variants.5.2.0+ox-023ee8551fb535cac47efdb9aaa0415c/target/cookie
    -> required by loading the OCaml compiler for context "default"
    -> required by _build/default/.dune/configurator

It seems that at some point `ignore-opam.patch` drifted out of sync with `Makefile.common-ox`: the former targets line 150 while the content being patched is around line 170.

My hypothesis is this: the line number mismatch was not a problem as long as Dune was using the external `patch` program (e.g. GNU patch) to apply patches; those seemed to be able to resolve the line mismatches. Recently, however, Dune switched to using a pure OCaml implementation of `patch` (https://github.com/ocaml/dune/pull/14177), which appears to be stricter around line numbers, leading to the patch failure above.

I tested this by pointing my Dune project against the branch I'm requesting to merge in and followed the reproduction steps of
https://github.com/oxcaml/opam-repository/issues/48, which now successfully builds my example OxCaml program. I have only tested this on my Arch Linux system so far.