### PR TITLE
mdx.2.6.0 is OxCaml compatible

### DIFF
--- a/.github/actions/test-oxcaml/action.yml
+++ b/.github/actions/test-oxcaml/action.yml
@@ -101,6 +101,7 @@ runs:
         opam-repositories: |
           oxcaml: ${{ steps.stage-oxcaml.outputs.path }}
           default: https://github.com/ocaml/opam-repository.git
+          mdx-2.6.0-temp: git+https://github.com/avsm/opam-repository.git#release-mdx-2.6.0
 
     - name: Install common opam packages
       shell: bash

--- a/.github/actions/test-oxcaml/broken-packages.txt
+++ b/.github/actions/test-oxcaml/broken-packages.txt
@@ -1,7 +1,5 @@
 # ocaml-variants is of course not actually broken!
 ocaml-variants
-# Broken since 5.2.0minus31
-mdx
 # Not co-installable with stdune 3.22+
 ocaml-lsp-server
 # ocamlformat-lib is broken since 5.2.0minus39

--- a/layout.sh
+++ b/layout.sh
@@ -69,6 +69,8 @@ for entry in $(sort -t: -k1,1V -k2,2r overrides); do
               # These packages are only patched from a given version in OxCaml - the older versions don't (necessarily) require patches
               chrome-trace|dune-action-plugin|dune-build-info|dune-glob|dune-private-libs|dune-rpc-lwt|dune-site|xdg)
                 constraint=' {>= "3.21.0"}';;
+              mdx)
+                constraint=' {< "2.6.0"}';;
               *)
                 constraint=''
             esac

--- a/packages/oxcaml-mdx/oxcaml-mdx.guard/opam
+++ b/packages/oxcaml-mdx/oxcaml-mdx.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-mdx-patches" "mdx" ]
+conflicts: [ "oxcaml-mdx-patches" "mdx" {< "2.6.0"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-merlin" {post} | "oxcaml-merlin-patches" {post})


### PR DESCRIPTION
cf. https://github.com/ocaml/opam-repository/pull/30305 - second commit will be blown away when it's merged.