### PR TITLE
allow upstream >=dune 3.24.2, >=eio.1.4 and >=mdx.2.6.0 through guards

### DIFF
--- a/.github/actions/test-oxcaml/broken-packages.txt
+++ b/.github/actions/test-oxcaml/broken-packages.txt
@@ -1,7 +1,5 @@
 # ocaml-variants is of course not actually broken!
 ocaml-variants
-# Broken since 5.2.0minus31
-mdx
 # Not co-installable with stdune 3.22+
 ocaml-lsp-server
 # ocamlformat-lib is broken since 5.2.0minus39

--- a/layout.sh
+++ b/layout.sh
@@ -67,8 +67,17 @@ for entry in $(sort -t: -k1,1V -k2,2r overrides); do
             mkdir -p "oxcaml-$entry/oxcaml-$entry.guard"
             case $entry in
               # These packages are only patched from a given version in OxCaml - the older versions don't (necessarily) require patches
+              # Dune and its libraries no longer require patches from 3.24.2
               chrome-trace|dune-action-plugin|dune-build-info|dune-glob|dune-private-libs|dune-rpc-lwt|dune-site|xdg)
-                constraint=' {>= "3.21.0"}';;
+                constraint=' {>= "3.21.0" & < "3.24.2"}';;
+              dune|dune-configurator|dune-rpc|dyn|fs-io|ocamlc-loc|ordering|stdune|top-closure)
+                constraint=' {< "3.24.2"}';;
+              # eio no longer requires patches from 1.4
+              eio|eio_linux|eio_main|eio_posix)
+                constraint=' {< "1.4"}';;
+              # mdx no longer requires patches from 2.6.0
+              mdx)
+                constraint=' {< "2.6.0"}';;
               *)
                 constraint=''
             esac

--- a/packages/oxcaml-chrome-trace/oxcaml-chrome-trace.guard/opam
+++ b/packages/oxcaml-chrome-trace/oxcaml-chrome-trace.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-chrome-trace-patches" "chrome-trace" {>= "3.21.0"} ]
+conflicts: [ "oxcaml-chrome-trace-patches" "chrome-trace" {>= "3.21.0" & < "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-ctypes" {post} | "oxcaml-ctypes-patches" {post})

--- a/packages/oxcaml-dune-action-plugin/oxcaml-dune-action-plugin.guard/opam
+++ b/packages/oxcaml-dune-action-plugin/oxcaml-dune-action-plugin.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-action-plugin-patches" "dune-action-plugin" {>= "3.21.0"} ]
+conflicts: [ "oxcaml-dune-action-plugin-patches" "dune-action-plugin" {>= "3.21.0" & < "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dune-build-info" {post} | "oxcaml-dune-build-info-patches" {post})

--- a/packages/oxcaml-dune-build-info/oxcaml-dune-build-info.guard/opam
+++ b/packages/oxcaml-dune-build-info/oxcaml-dune-build-info.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-build-info-patches" "dune-build-info" {>= "3.21.0"} ]
+conflicts: [ "oxcaml-dune-build-info-patches" "dune-build-info" {>= "3.21.0" & < "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dune-configurator" {post} | "oxcaml-dune-configurator-patches" {post})

--- a/packages/oxcaml-dune-configurator/oxcaml-dune-configurator.guard/opam
+++ b/packages/oxcaml-dune-configurator/oxcaml-dune-configurator.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-configurator-patches" "dune-configurator" ]
+conflicts: [ "oxcaml-dune-configurator-patches" "dune-configurator" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dune-glob" {post} | "oxcaml-dune-glob-patches" {post})

--- a/packages/oxcaml-dune-glob/oxcaml-dune-glob.guard/opam
+++ b/packages/oxcaml-dune-glob/oxcaml-dune-glob.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-glob-patches" "dune-glob" {>= "3.21.0"} ]
+conflicts: [ "oxcaml-dune-glob-patches" "dune-glob" {>= "3.21.0" & < "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dune-private-libs" {post} | "oxcaml-dune-private-libs-patches" {post})

--- a/packages/oxcaml-dune-private-libs/oxcaml-dune-private-libs.guard/opam
+++ b/packages/oxcaml-dune-private-libs/oxcaml-dune-private-libs.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-private-libs-patches" "dune-private-libs" {>= "3.21.0"} ]
+conflicts: [ "oxcaml-dune-private-libs-patches" "dune-private-libs" {>= "3.21.0" & < "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dune-rpc" {post} | "oxcaml-dune-rpc-patches" {post})

--- a/packages/oxcaml-dune-rpc-lwt/oxcaml-dune-rpc-lwt.guard/opam
+++ b/packages/oxcaml-dune-rpc-lwt/oxcaml-dune-rpc-lwt.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-rpc-lwt-patches" "dune-rpc-lwt" {>= "3.21.0"} ]
+conflicts: [ "oxcaml-dune-rpc-lwt-patches" "dune-rpc-lwt" {>= "3.21.0" & < "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dune-site" {post} | "oxcaml-dune-site-patches" {post})

--- a/packages/oxcaml-dune-rpc/oxcaml-dune-rpc.guard/opam
+++ b/packages/oxcaml-dune-rpc/oxcaml-dune-rpc.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-rpc-patches" "dune-rpc" ]
+conflicts: [ "oxcaml-dune-rpc-patches" "dune-rpc" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dune-rpc-lwt" {post} | "oxcaml-dune-rpc-lwt-patches" {post})

--- a/packages/oxcaml-dune-site/oxcaml-dune-site.guard/opam
+++ b/packages/oxcaml-dune-site/oxcaml-dune-site.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-site-patches" "dune-site" {>= "3.21.0"} ]
+conflicts: [ "oxcaml-dune-site-patches" "dune-site" {>= "3.21.0" & < "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dyn" {post} | "oxcaml-dyn-patches" {post})

--- a/packages/oxcaml-dune/oxcaml-dune.guard/opam
+++ b/packages/oxcaml-dune/oxcaml-dune.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dune-patches" "dune" ]
+conflicts: [ "oxcaml-dune-patches" "dune" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-dune-action-plugin" {post} | "oxcaml-dune-action-plugin-patches" {post})

--- a/packages/oxcaml-dyn/oxcaml-dyn.guard/opam
+++ b/packages/oxcaml-dyn/oxcaml-dyn.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-dyn-patches" "dyn" ]
+conflicts: [ "oxcaml-dyn-patches" "dyn" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-eio" {post} | "oxcaml-eio-patches" {post})

--- a/packages/oxcaml-eio/oxcaml-eio.guard/opam
+++ b/packages/oxcaml-eio/oxcaml-eio.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-eio-patches" "eio" ]
+conflicts: [ "oxcaml-eio-patches" "eio" {< "1.4"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-eio_linux" {post} | "oxcaml-eio_linux-patches" {post})

--- a/packages/oxcaml-eio_linux/oxcaml-eio_linux.guard/opam
+++ b/packages/oxcaml-eio_linux/oxcaml-eio_linux.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-eio_linux-patches" "eio_linux" ]
+conflicts: [ "oxcaml-eio_linux-patches" "eio_linux" {< "1.4"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-eio_main" {post} | "oxcaml-eio_main-patches" {post})

--- a/packages/oxcaml-eio_main/oxcaml-eio_main.guard/opam
+++ b/packages/oxcaml-eio_main/oxcaml-eio_main.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-eio_main-patches" "eio_main" ]
+conflicts: [ "oxcaml-eio_main-patches" "eio_main" {< "1.4"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-eio_posix" {post} | "oxcaml-eio_posix-patches" {post})

--- a/packages/oxcaml-eio_posix/oxcaml-eio_posix.guard/opam
+++ b/packages/oxcaml-eio_posix/oxcaml-eio_posix.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-eio_posix-patches" "eio_posix" ]
+conflicts: [ "oxcaml-eio_posix-patches" "eio_posix" {< "1.4"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-fs-io" {post} | "oxcaml-fs-io-patches" {post})

--- a/packages/oxcaml-fs-io/oxcaml-fs-io.guard/opam
+++ b/packages/oxcaml-fs-io/oxcaml-fs-io.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-fs-io-patches" "fs-io" ]
+conflicts: [ "oxcaml-fs-io-patches" "fs-io" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-gen_js_api" {post} | "oxcaml-gen_js_api-patches" {post})

--- a/packages/oxcaml-mdx/oxcaml-mdx.guard/opam
+++ b/packages/oxcaml-mdx/oxcaml-mdx.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-mdx-patches" "mdx" ]
+conflicts: [ "oxcaml-mdx-patches" "mdx" {< "2.6.0"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-merlin" {post} | "oxcaml-merlin-patches" {post})

--- a/packages/oxcaml-ocamlc-loc/oxcaml-ocamlc-loc.guard/opam
+++ b/packages/oxcaml-ocamlc-loc/oxcaml-ocamlc-loc.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-ocamlc-loc-patches" "ocamlc-loc" ]
+conflicts: [ "oxcaml-ocamlc-loc-patches" "ocamlc-loc" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-ocamlfind" {post} | "oxcaml-ocamlfind-patches" {post})

--- a/packages/oxcaml-ordering/oxcaml-ordering.guard/opam
+++ b/packages/oxcaml-ordering/oxcaml-ordering.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-ordering-patches" "ordering" ]
+conflicts: [ "oxcaml-ordering-patches" "ordering" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-otoml" {post} | "oxcaml-otoml-patches" {post})

--- a/packages/oxcaml-stdune/oxcaml-stdune.guard/opam
+++ b/packages/oxcaml-stdune/oxcaml-stdune.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-stdune-patches" "stdune" ]
+conflicts: [ "oxcaml-stdune-patches" "stdune" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-top-closure" {post} | "oxcaml-top-closure-patches" {post})

--- a/packages/oxcaml-top-closure/oxcaml-top-closure.guard/opam
+++ b/packages/oxcaml-top-closure/oxcaml-top-closure.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-top-closure-patches" "top-closure" ]
+conflicts: [ "oxcaml-top-closure-patches" "top-closure" {< "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-topkg" {post} | "oxcaml-topkg-patches" {post})

--- a/packages/oxcaml-xdg/oxcaml-xdg.guard/opam
+++ b/packages/oxcaml-xdg/oxcaml-xdg.guard/opam
@@ -6,7 +6,7 @@ authors: "David Allsopp"
 license: "CC0-1.0+"
 homepage: "https://oxcaml.org"
 bug-reports: "https://github.com/oxcaml/opam-repository/issues"
-conflicts: [ "oxcaml-xdg-patches" "xdg" {>= "3.21.0"} ]
+conflicts: [ "oxcaml-xdg-patches" "xdg" {>= "3.21.0" & < "3.24.2"} ]
 messages: ["WARNING! An older version of OxCaml is being installed" {oxcaml:version = "archived"}]
 depends: [
   ("oxcaml-zarith" {post} | "oxcaml-zarith-patches" {post})


### PR DESCRIPTION
allow upstream >=dune 3.24.2, >=eio.1.4 and >=mdx.2.6.0 to be installable

All of these have been fixed to build with oxcaml in recent releases

This allows my website monorepo to build with minus39. yay!